### PR TITLE
Add script for deploying with folder structure

### DIFF
--- a/1.27-openssl-1.1/Dockerfile
+++ b/1.27-openssl-1.1/Dockerfile
@@ -1,0 +1,7 @@
+FROM osig/rust-ubuntu:1.27
+
+RUN \
+    wget https://github.com/openssl/openssl/archive/OpenSSL_1_1_0-stable.zip && \
+    unzip OpenSSL_1_1_0-stable.zip && cd openssl-OpenSSL_1_1_0-stable && \
+    ./config && make -j $(nproc) && make install
+ENV LD_LIBRARY_PATH /usr/local/lib

--- a/1.27/Dockerfile
+++ b/1.27/Dockerfile
@@ -1,54 +1,5 @@
-FROM ubuntu:16.04
+FROM osig/rust-ubuntu:base-v1
 
-RUN apt-get update && apt-get install -y \
-  autoconf \
-  automake \
-  bzip2 \
-  dpkg-dev \
-  file \
-  g++ \
-  gcc \
-  imagemagick \
-  libbz2-dev \
-  libc6-dev \
-  libcurl4-openssl-dev \
-  libdb-dev \
-  libevent-dev \
-  libffi-dev \
-  libgdbm-dev \
-  libgeoip-dev \
-  libglib2.0-dev \
-  libjpeg-dev \
-  libkrb5-dev \
-  liblzma-dev \
-  libmagickcore-dev \
-  libmagickwand-dev \
-  libncurses5-dev \
-  libncursesw5-dev \
-  libpng-dev \
-  libpq-dev \
-  libreadline-dev \
-  libsqlite3-dev \
-  libssl-dev \
-  libtool \
-  libwebp-dev \
-  libxml2-dev \
-  libxslt-dev \
-  libyaml-dev \
-  make \
-  ssh \
-  git \
-  time \
-  lsof \
-  patch \
-  xz-utils \
-  zlib1g-dev
-
-ENV RUSTUP_HOME=/usr/local/rustup \
-  CARGO_HOME=/usr/local/cargo \
-  PATH=/usr/local/cargo/bin:$PATH
-
-RUN apt-get install -y wget
 RUN set -eux; \
   \
   # this "case" statement is generated via "update.sh"

--- a/base-v1/Dockerfile
+++ b/base-v1/Dockerfile
@@ -1,0 +1,51 @@
+FROM ubuntu:16.04
+
+RUN apt-get update && apt-get install -y \
+  autoconf \
+  automake \
+  bzip2 \
+  dpkg-dev \
+  file \
+  g++ \
+  gcc \
+  imagemagick \
+  libbz2-dev \
+  libc6-dev \
+  libcurl4-openssl-dev \
+  libdb-dev \
+  libevent-dev \
+  libffi-dev \
+  libgdbm-dev \
+  libgeoip-dev \
+  libglib2.0-dev \
+  libjpeg-dev \
+  libkrb5-dev \
+  liblzma-dev \
+  libmagickcore-dev \
+  libmagickwand-dev \
+  libncurses5-dev \
+  libncursesw5-dev \
+  libpng-dev \
+  libpq-dev \
+  libreadline-dev \
+  libsqlite3-dev \
+  libssl-dev \
+  libtool \
+  libwebp-dev \
+  libxml2-dev \
+  libxslt-dev \
+  libyaml-dev \
+  make \
+  ssh \
+  git \
+  time \
+  lsof \
+  patch \
+  xz-utils \
+  wget \
+  unzip \
+  zlib1g-dev
+
+ENV RUSTUP_HOME=/usr/local/rustup \
+  CARGO_HOME=/usr/local/cargo \
+  PATH=/usr/local/cargo/bin:$PATH

--- a/deploy.sh
+++ b/deploy.sh
@@ -1,0 +1,23 @@
+#!/usr/bin/env bash
+
+# https://www.gnu.org/software/bash/manual/html_node/The-Set-Builtin.html
+# -e => Exit on error instead of continuing
+set -e
+
+# Should not require user input if already logged in
+docker login
+
+# `sort -r` => reverse sort so that 1.27.0 goes before 1.27.0-*
+# `sed 's|/||'` => remove trailing /
+for DIR in `/bin/ls -d */ | sort -r | sed 's|/||'`
+do
+  echo "DIR: $DIR"
+  pushd $DIR
+
+  IMAGE="osig/rust-ubuntu:$DIR"
+
+  docker build -t $IMAGE .
+  docker push $IMAGE
+
+  popd
+done


### PR DESCRIPTION
This change moves our docker images into folders so that we can maintain a history of the Dockerfiles used to build each tag.
