### PR TITLE
Add comment on building OpenSSL

### DIFF
--- a/1.27-openssl-1.1/Dockerfile
+++ b/1.27-openssl-1.1/Dockerfile
@@ -1,5 +1,6 @@
 FROM osig/rust-ubuntu:1.27
 
+# Cannot use OneSignal/openssl pre-built binary since it needs header files as well.
 RUN \
     wget https://github.com/openssl/openssl/archive/OpenSSL_1_1_0-stable.zip && \
     unzip OpenSSL_1_1_0-stable.zip && cd openssl-OpenSSL_1_1_0-stable && \


### PR DESCRIPTION
We cannot introduce the newly built OpenSSL binary here because it
needs C header files to build rust applications.