### PR TITLE
feat: add clang to all images

### DIFF
--- a/base-v1/Dockerfile
+++ b/base-v1/Dockerfile
@@ -1,11 +1,13 @@
 FROM ubuntu:16.04
 
+# clang is installed to support building rdkafka crate
 RUN apt-get update && apt-get install -y \
   autoconf \
   automake \
   bzip2 \
-  dpkg-dev \
+  clang \
   curl \
+  dpkg-dev \
   file \
   g++ \
   gcc \


### PR DESCRIPTION
Each project installs clang as a CI build step. Sometimes the package
install is throttled down to kB/s. Most of our rust projects use the
rdkafka crate which requires clang to build. It is worth the additional
image size of ~100MB and associated download time to eliminate huge
variance in CI build times when we are bandwidth throttled by the
package mirror