### PR TITLE
Add base runtime image

### DIFF
--- a/base-runtime/Dockerfile
+++ b/base-runtime/Dockerfile
@@ -1,0 +1,8 @@
+# This is the basic runtime image that our Rust services need. It contains a
+# base ubuntu image and openssl.
+#
+# This is the minimal ubuntu image
+FROM ubuntu:18.04
+
+# We require openssl installed on the container
+RUN apt-get update && apt-get install -y libssl1.0.0 libssl-dev


### PR DESCRIPTION
We have similar runtime dependencies across our Rust projects. We should
use the same base image across our Rust projects, so that we don't have
to re-install these packages in every CI pipeline.