### PR TITLE
Include ca-certificates in runtime image

### DIFF
--- a/base-runtime/Dockerfile
+++ b/base-runtime/Dockerfile
@@ -21,4 +21,5 @@ ENTRYPOINT [ "/usr/bin/envoy-preflight" ]
 RUN apt-get update && apt-get install -y \
     libssl1.0.0 \
     libssl-dev \
+    ca-certificates \
     && rm -rf /var/lib/apt/lists/*


### PR DESCRIPTION
I believe this is required to get sentry working in the containers.