### PR TITLE
Update the base build image and run image to 20.04

### DIFF
--- a/1.44.1/Dockerfile
+++ b/1.44.1/Dockerfile
@@ -1,4 +1,4 @@
-FROM osig/rust-ubuntu:base-v1
+FROM osig/rust-ubuntu:base-v2
 
 RUN set -eux; \
   \

--- a/base-runtime/Dockerfile
+++ b/base-runtime/Dockerfile
@@ -1,21 +1,8 @@
-# The first build step here will build the envoy-preflight binary so that it
-# can be included in our base image. envoy-preflight is used to ensure that
-# envoy has started up before our app starts.
-FROM golang
-
-RUN go get github.com/monzo/envoy-preflight
-
 # This is the basic runtime image that our Rust services need. It contains a
 # base ubuntu image and openssl.
 #
 # This is the minimal ubuntu image
-FROM ubuntu:18.04
-
-COPY --from=0 /go/bin/envoy-preflight /usr/bin/
-
-# The entrypoint should not be overridden by app images, the path to the app
-# executable should be provided as an image argument.
-ENTRYPOINT [ "/usr/bin/envoy-preflight" ]
+FROM ubuntu:20:04
 
 # We require openssl installed on the container
 RUN apt-get update && apt-get install -y \

--- a/base-v2/Dockerfile
+++ b/base-v2/Dockerfile
@@ -1,0 +1,54 @@
+FROM ubuntu:20.04
+
+# clang is installed to support building rdkafka crate
+RUN apt-get update && apt-get install -y \
+  autoconf \
+  automake \
+  bzip2 \
+  clang \
+  curl \
+  dpkg-dev \
+  file \
+  g++ \
+  gcc \
+  imagemagick \
+  libbz2-dev \
+  libc6-dev \
+  libcurl4-openssl-dev \
+  libdb-dev \
+  libevent-dev \
+  libffi-dev \
+  libgdbm-dev \
+  libgeoip-dev \
+  libglib2.0-dev \
+  libjpeg-dev \
+  libkrb5-dev \
+  liblzma-dev \
+  libmagickcore-dev \
+  libmagickwand-dev \
+  libncurses5-dev \
+  libncursesw5-dev \
+  libpng-dev \
+  libpq-dev \
+  libreadline-dev \
+  libsqlite3-dev \
+  libssl-dev \
+  libtool \
+  libwebp-dev \
+  libxml2-dev \
+  libxslt-dev \
+  libyaml-dev \
+  make \
+  ssh \
+  git \
+  time \
+  lsof \
+  patch \
+  xz-utils \
+  wget \
+  unzip \
+  zlib1g-dev
+
+ENV RUSTUP_HOME=/usr/local/rustup \
+  CARGO_HOME=/usr/local/cargo \
+  PATH=/usr/local/cargo/bin:$PATH


### PR DESCRIPTION
The build image update will be limited to the new 1.44.1 image, but the
runtime image will be included in all newly built images by default.