### PR TITLE
Correctly set $PATH in 1.46-ruby-capnp image

### DIFF
--- a/1.46-ruby-capnp/Dockerfile
+++ b/1.46-ruby-capnp/Dockerfile
@@ -3,7 +3,8 @@ FROM osig/rust-ubuntu:1.46
 ENV ONESIGNAL_CAPNPROTO_RELEASE_URL="https://github.com/OneSignal/capnproto-debian/releases/download/onesignal-0.6.1-1" \
   ONESIGNAL_CAPNPROTO_DEB="capnproto_0.6.1-1_amd64.deb" \
   ONESIGNAL_LIBCAPNP_DEB="libcapnp-0.6.1_0.6.1-1_amd64.deb" \
-  ONESIGNAL_LIBCAPNP_DEV_DEB="libcapnp-dev_0.6.1-1_amd64.deb"
+  ONESIGNAL_LIBCAPNP_DEV_DEB="libcapnp-dev_0.6.1-1_amd64.deb" \
+  PATH="/root/.rbenv/bin:${PATH}"
 
 RUN set -ex \
   && apt-get update \
@@ -15,7 +16,6 @@ RUN set -ex \
   && curl -sSLO "${ONESIGNAL_CAPNPROTO_RELEASE_URL}/${ONESIGNAL_LIBCAPNP_DEV_DEB}" \
   && dpkg -i "${ONESIGNAL_CAPNPROTO_DEB}" "${ONESIGNAL_LIBCAPNP_DEB}" "${ONESIGNAL_LIBCAPNP_DEV_DEB}"\
   && git clone https://github.com/rbenv/rbenv.git ~/.rbenv \
-  && export PATH="$HOME/.rbenv/bin:$PATH" \
   && mkdir -p "$(rbenv root)"/plugins \
   && git clone https://github.com/rbenv/ruby-build.git "$(rbenv root)"/plugins/ruby-build\
   && eval "$(rbenv init -)" \
@@ -23,3 +23,5 @@ RUN set -ex \
   && rbenv global 2.4.4 \
   && gem install thermite \
   && gem install bundler
+
+RUN echo "eval \"\$(rbenv init -)\"" >> /root/.bashrc


### PR DESCRIPTION
This seems to have expected the `export PATH=...` command to persist
into the container's environment, but it seems to require an explicit
`ENV PATH=...` to accomplish that.

I'm also hardcoding to `/root` instead of `$HOME` because `$HOME`
expands to an empty string inside an `ENV` instruction (even though it's
correct in a `RUN` instruction).